### PR TITLE
Lockscreen Settings: Allow disabling ripple effect on unlock

### DIFF
--- a/res/values/powerhub_strings.xml
+++ b/res/values/powerhub_strings.xml
@@ -732,5 +732,9 @@
     <!-- Notification count -->
     <string name="statusbar_notif_count_title">Show notification count</string>
     <string name="statusbar_notif_count_summary">Display the number of pending notifications</string>
+ 
+    <!-- Fingerprint Ripple Effect -->
+    <string name="enable_fingerprint_ripple_effect_title">Ripple effect</string>
+    <string name="enable_fingerprint_ripple_effect_summary">Show ripple effect on unlock with fingerprint</string>
 
 </resources>

--- a/res/xml/powerhub_lockscreen.xml
+++ b/res/xml/powerhub_lockscreen.xml
@@ -81,6 +81,12 @@
             android:title="@string/show_lockscreen_media_art_title"
             android:defaultValue="true" />
 
+	<com.power.hub.preferences.SystemSettingSwitchPreference
+            android:key="enable_ripple_effect"
+            android:title="@string/enable_fingerprint_ripple_effect_title"
+            android:summary="@string/enable_fingerprint_ripple_effect_summary"
+            android:defaultValue="false" />
+
         <com.power.hub.preferences.SystemSettingSeekBarPreference
             android:key="lockscreen_media_blur"
             android:title="@string/lockscreen_media_blur_title"


### PR DESCRIPTION
 [2/2]
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

Signed-off-by: spezi77 <spezi7713@gmx.net>
Change-Id: I59ba77de558c143609194ba5ca0b9e298623c39c
Signed-off-by: Hưng Phan <phandinhhungvp2001@gmail.com>